### PR TITLE
fix: set pane background via window-style to avoid unzoom/focus steal

### DIFF
--- a/scripts/agent-state.sh
+++ b/scripts/agent-state.sh
@@ -174,25 +174,21 @@ restore_active_border_style() {
     restore_window_option "$window_id" "pane-active-border-style" "$orig_key"
 }
 
+# Set the pane background through the pane-level `window-style` option rather
+# than `select-pane -P`. On tmux 3.x, `select-pane -P <style>` targeting a
+# non-active pane changes the active pane and clears the window zoom flag as a
+# side effect, so tinting a background agent's pane unzooms the user's current
+# view and steals focus. `set-option -p window-style` sets only the pane
+# option and leaves the active pane and zoom untouched.
 reset_pane_style() {
     local pane_id="$1"
-    local active
-    active=$(tmux display-message -p '#{pane_id}')
-    tmux select-pane -t "$pane_id" -P "bg=default"
-    if [ "$pane_id" != "$active" ]; then
-        tmux select-pane -t "$active"
-    fi
+    tmux set-option -pu -t "$pane_id" window-style 2>/dev/null || true
 }
 
 apply_pane_style() {
     local pane_id="$1"
     local bg="$2"
-    local active
-    active=$(tmux display-message -p '#{pane_id}')
-    tmux select-pane -t "$pane_id" -P "bg=$bg"
-    if [ "$pane_id" != "$active" ]; then
-        tmux select-pane -t "$active"
-    fi
+    tmux set-option -p -t "$pane_id" window-style "bg=$bg" 2>/dev/null || true
 }
 
 pane_exists() {

--- a/scripts/pane-focus-in.sh
+++ b/scripts/pane-focus-in.sh
@@ -81,7 +81,7 @@ window_border_key="TMUX_AGENT_WINDOW_${window_id}_ORIG_ACTIVE_BORDER_STYLE"
 
 pending_reset=$(tmux_get_env "$pending_reset_key")
 if [ "$pending_reset" = "1" ]; then
-    tmux select-pane -t "$pane_id" -P "bg=default"
+    tmux set-option -pu -t "$pane_id" window-style 2>/dev/null || true
     restore_window_option "$window_id" "pane-active-border-style" "$window_border_key"
     tmux_unset_env "$pending_reset_key"
 fi
@@ -99,7 +99,7 @@ done_window_border_key="TMUX_AGENT_WINDOW_${done_window}_ORIG_ACTIVE_BORDER_STYL
 # Needs-input visuals are cleared when focus returns to the source pane/window.
 if [ "$state" = "needs-input" ]; then
     restore_window_title_style "$window_id"
-    tmux select-pane -t "$pane_id" -P "bg=default"
+    tmux set-option -pu -t "$pane_id" window-style 2>/dev/null || true
     restore_window_option "$window_id" "pane-active-border-style" "$window_border_key"
 fi
 

--- a/scripts/reset_all.sh
+++ b/scripts/reset_all.sh
@@ -51,7 +51,7 @@ tmux_unset_env "TMUX_AGENT_ANIMATION_FRAME"
 active_pane=$(tmux display-message -p '#{pane_id}')
 while IFS= read -r pane_id; do
     [ -z "$pane_id" ] && continue
-    tmux select-pane -t "$pane_id" -P "bg=default" 2>/dev/null || true
+    tmux set-option -pu -t "$pane_id" window-style 2>/dev/null || true
 done < <(tmux list-panes -a -F '#{pane_id}')
 tmux select-pane -t "$active_pane" 2>/dev/null || true
 


### PR DESCRIPTION
## Problem

When an agent updates its state in a background pane (`needs-input` or `done`), the pane-background indicator unzooms the user's current window and moves focus to the triggering pane. Anyone who has zoomed one pane to concentrate on it loses that zoom whenever any other tracked pane changes state, and focus jumps away from where they were working.

## Root cause

`apply_pane_style` and `reset_pane_style` in `scripts/agent-state.sh` set the pane background with `tmux select-pane -t <pane> -P "bg=..."`. On tmux 3.x, `select-pane -P` targeting a non-active pane changes the active pane and clears the window `zoomed` flag as a side effect, even when the only intent is to set a style. The functions then call `select-pane -t <previous-active>` to put focus back, which restores the active pane but cannot restore the zoom.

Reproduction on tmux 3.7b, starting from a zoomed 2-pane window:

```
zoom pane %42 (active)               -> window_zoomed_flag=1  active=%42
select-pane -t %43 -P "bg=colour52"  -> window_zoomed_flag=0  active=%43
```

The same side effect fires for every state that tints a background pane, so a long-running agent that finishes in a hidden pane yanks the user out of their zoom.

## Fix

Set the pane background through the pane-level `window-style` option instead of `select-pane -P`:

```
tmux set-option -p -t <pane> window-style "bg=<color>"   # apply
tmux set-option -pu -t <pane> window-style               # clear
```

`set-option -p` writes only the pane option. It leaves the active pane and the zoom flag untouched, so no focus juggling or restore call is needed.

This PR converts every set and clear site to `window-style` so a tint applied one way is cleared the same way:

- `scripts/agent-state.sh`: `apply_pane_style` and `reset_pane_style`
- `scripts/pane-focus-in.sh`: the two focus-in clear paths
- `scripts/reset_all.sh`: the bulk reset loop

## Verification

Primitive, on tmux 3.7b, starting from a zoomed window:

```
zoom pane %47 (active)
set-option -p -t %48 window-style "bg=colour52"
-> window_zoomed_flag=1  active=%47  pane %48 background=colour52
set-option -pu -t %48 window-style
-> window-style cleared
```

End to end: a background pane transitioning to `done` while another pane is zoomed keeps the zoom and the active pane, tints the background pane, and clears the tint when that pane is focused.

## Compatibility and scope

`window-style` is a standard pane option in tmux 3.x, and both `select-pane -P` and `set-option -p window-style` set the pane background, so the rendered result is unchanged. The Knight Rider animation writes a status-bar frame index and does not color panes, so it is unaffected. The active-pane border, window-title styling, and status indicators use `set-window-option` and status formats rather than `select-pane`, so they are unaffected as well.
